### PR TITLE
Use password for UDP proxy

### DIFF
--- a/backend/udp/server.js
+++ b/backend/udp/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const udp = require('dgram')
 const axios = require('axios')
 
@@ -12,7 +13,18 @@ client.on('message',function(msg,info){
 
     if ("model" in data) {
         const {model, ...rest} = data
-        axios.post("http://localhost:9000/api/" + data['model'], rest)
+        const API_USERNAME = process.env?.["API_USERNAME"] ?? ""
+        const API_PASSWORD = process.env?.["API_PASSWORD"] ?? ""
+        axios.post(
+            "http://localhost:9000/api/" + data['model'],
+            rest,
+            {
+                headers: {
+                    "username": API_USERNAME,
+                    "password": API_PASSWORD,
+                }
+            }
+        )
     }
 });
 


### PR DESCRIPTION
When the telemetry was locked down to authenticated users in https://github.com/Solar-Gators/Pit-GUI/commit/a4c4e002dd29ff25a0e821edd43506b4f6893c47 we forgot to handle the UDP proxy.

Verified this works by sending an empty message to the bms rx2:
<img width="520" alt="Screenshot 2024-02-27 at 7 11 41 PM" src="https://github.com/Solar-Gators/Pit-GUI/assets/7267438/a6a02d96-7060-43db-ac23-6efe81d3f722">
